### PR TITLE
Fix filtered hotels query

### DIFF
--- a/app/query_objects/filtered_hotels.rb
+++ b/app/query_objects/filtered_hotels.rb
@@ -43,6 +43,6 @@ class FilteredHotels
   def by_near(relation, near_params)
     return relation unless near_params[:coordinates].all?
 
-    relation.near(near_params[:coordinates], near_params[:radius] || DEFAULT_RADIUS)
+    relation.near(near_params[:coordinates], near_params[:radius].presence || DEFAULT_RADIUS)
   end
 end


### PR DESCRIPTION
# Summary
Fix error occurring while searching hotels with empty value on radius filter.

# Test plan

List of steps to manually test introduced functionality:

* Go to Application
* Click on Find button on the main page of the application
* See that all hotels listed on the page (There is no Server Error)
