### PR TITLE
Replace callback to reindex multisearch table with interactor

### DIFF
--- a/app/controllers/hotels_controller.rb
+++ b/app/controllers/hotels_controller.rb
@@ -14,7 +14,7 @@ class HotelsController < ApplicationController
   end
 
   def create
-    hotel.save
+    self.hotel = CreateHotel.call(record: hotel).record
 
     respond_with hotel, location: hotels_path
   end
@@ -23,13 +23,13 @@ class HotelsController < ApplicationController
   end
 
   def update
-    hotel.update(hotel_params)
+    self.hotel = UpdateHotel.call(record: hotel, record_params: hotel_params).record
 
     respond_with hotel, location: hotels_path
   end
 
   def destroy
-    hotel.destroy
+    self.hotel = DestroyHotel.call(record: hotel).record
 
     respond_with hotel
   end

--- a/app/interactors/create_hotel.rb
+++ b/app/interactors/create_hotel.rb
@@ -1,0 +1,6 @@
+class CreateHotel
+  include Interactor::Organizer
+
+  organize Hotels::Create,
+    ReindexMultisearchTable
+end

--- a/app/interactors/create_hotel.rb
+++ b/app/interactors/create_hotel.rb
@@ -1,6 +1,6 @@
 class CreateHotel
   include Interactor::Organizer
 
-  organize Hotels::Create,
+  organize Hotels::Save,
     ReindexMultisearchTable
 end

--- a/app/interactors/destroy_hotel.rb
+++ b/app/interactors/destroy_hotel.rb
@@ -1,0 +1,6 @@
+class DestroyHotel
+  include Interactor::Organizer
+
+  organize Hotels::Destroy,
+    ReindexMultisearchTable
+end

--- a/app/interactors/hotels/create.rb
+++ b/app/interactors/hotels/create.rb
@@ -1,0 +1,9 @@
+class Hotels::Create
+  include Interactor
+
+  delegate :record, to: :context
+
+  def call
+    record.save || context.fail!
+  end
+end

--- a/app/interactors/hotels/destroy.rb
+++ b/app/interactors/hotels/destroy.rb
@@ -1,7 +1,7 @@
 class Hotels::Destroy
   include Interactor
 
-  delegate :record, :record_params, to: :context
+  delegate :record, to: :context
 
   def call
     record.destroy || context.fail!

--- a/app/interactors/hotels/destroy.rb
+++ b/app/interactors/hotels/destroy.rb
@@ -1,0 +1,9 @@
+class Hotels::Destroy
+  include Interactor
+
+  delegate :record, :record_params, to: :context
+
+  def call
+    record.destroy || context.fail!
+  end
+end

--- a/app/interactors/hotels/save.rb
+++ b/app/interactors/hotels/save.rb
@@ -1,4 +1,4 @@
-class Hotels::Create
+class Hotels::Save
   include Interactor
 
   delegate :record, to: :context

--- a/app/interactors/hotels/update.rb
+++ b/app/interactors/hotels/update.rb
@@ -1,0 +1,9 @@
+class Hotels::Update
+  include Interactor
+
+  delegate :record, :record_params, to: :context
+
+  def call
+    record.update(record_params) || context.fail!
+  end
+end

--- a/app/interactors/reindex_multisearch_table.rb
+++ b/app/interactors/reindex_multisearch_table.rb
@@ -2,6 +2,7 @@ class ReindexMultisearchTable
   include Interactor
 
   delegate :record, to: :context
+  delegate :class, :id, to: :record, prefix: true
 
   def call
     reindex_multisearch_table if searchable_attributes_changed? || record_deleted?
@@ -10,7 +11,7 @@ class ReindexMultisearchTable
   private
 
   def reindex_multisearch_table
-    PgSearch::Multisearch.rebuild(record.class)
+    PgSearch::Multisearch.rebuild(record_class)
   end
 
   def searchable_attributes_changed?
@@ -18,10 +19,10 @@ class ReindexMultisearchTable
   end
 
   def record_deleted?
-    !record.class.exists?(record.id)
+    !record_class.exists?(record_id)
   end
 
   def searchable_attributes
-    record.class::SEARCHABLE_ATTRIBUTES
+    record_class::SEARCHABLE_ATTRIBUTES
   end
 end

--- a/app/interactors/reindex_multisearch_table.rb
+++ b/app/interactors/reindex_multisearch_table.rb
@@ -1,0 +1,27 @@
+class ReindexMultisearchTable
+  include Interactor
+
+  delegate :record, to: :context
+
+  def call
+    reindex_multisearch_table if search_attributes_changed? || record_deleted?
+  end
+
+  private
+
+  def reindex_multisearch_table
+    PgSearch::Multisearch.rebuild(record.class)
+  end
+
+  def search_attributes_changed?
+    record.previous_changes.slice(*search_attributes).any?
+  end
+
+  def record_deleted?
+    !record.class.exists?(record.id)
+  end
+
+  def search_attributes
+    record.class::SEARCH_ATTRIBUTES
+  end
+end

--- a/app/interactors/reindex_multisearch_table.rb
+++ b/app/interactors/reindex_multisearch_table.rb
@@ -4,7 +4,7 @@ class ReindexMultisearchTable
   delegate :record, to: :context
 
   def call
-    reindex_multisearch_table if search_attributes_changed? || record_deleted?
+    reindex_multisearch_table if searchable_attributes_changed? || record_deleted?
   end
 
   private
@@ -13,15 +13,15 @@ class ReindexMultisearchTable
     PgSearch::Multisearch.rebuild(record.class)
   end
 
-  def search_attributes_changed?
-    record.previous_changes.slice(*search_attributes).any?
+  def searchable_attributes_changed?
+    record.previous_changes.slice(*searchable_attributes).any?
   end
 
   def record_deleted?
     !record.class.exists?(record.id)
   end
 
-  def search_attributes
-    record.class::SEARCH_ATTRIBUTES
+  def searchable_attributes
+    record.class::SEARCHABLE_ATTRIBUTES
   end
 end

--- a/app/interactors/update_hotel.rb
+++ b/app/interactors/update_hotel.rb
@@ -1,0 +1,6 @@
+class UpdateHotel
+  include Interactor::Organizer
+
+  organize Hotels::Update,
+    ReindexMultisearchTable
+end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,6 +1,6 @@
 class City < ApplicationRecord
   include PgSearch
-  include ReindexMultisearchTable
+  include ReindexMultisearch
 
   multisearchable against: %i[name country]
 

--- a/app/models/concerns/reindex_multisearch.rb
+++ b/app/models/concerns/reindex_multisearch.rb
@@ -1,4 +1,4 @@
-module ReindexMultisearchTable
+module ReindexMultisearch
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/hotel.rb
+++ b/app/models/hotel.rb
@@ -1,9 +1,9 @@
 class Hotel < ApplicationRecord
   include PgSearch
 
-  SEARCH_ATTRIBUTES = %i[name address].freeze
+  SEARCHABLE_ATTRIBUTES = %i[name address].freeze
 
-  multisearchable against: SEARCH_ATTRIBUTES
+  multisearchable against: SEARCHABLE_ATTRIBUTES
 
   geocoded_by %i[latitude longitude]
 

--- a/app/models/hotel.rb
+++ b/app/models/hotel.rb
@@ -1,8 +1,9 @@
 class Hotel < ApplicationRecord
   include PgSearch
-  include ReindexMultisearchTable
 
-  multisearchable against: %i[name address]
+  SEARCH_ATTRIBUTES = %i[name address].freeze
+
+  multisearchable against: SEARCH_ATTRIBUTES
 
   geocoded_by %i[latitude longitude]
 

--- a/spec/interactors/create_hotel_spec.rb
+++ b/spec/interactors/create_hotel_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe CreateHotel do
+  let(:expected_interactors) do
+    [
+      Hotels::Save,
+      ReindexMultisearchTable
+    ]
+  end
+
+  it "organizes other interactors" do
+    expect(described_class.organized).to eq(expected_interactors)
+  end
+end

--- a/spec/interactors/destroy_hotel_spec.rb
+++ b/spec/interactors/destroy_hotel_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe DestroyHotel do
+  let(:expected_interactors) do
+    [
+      Hotels::Destroy,
+      ReindexMultisearchTable
+    ]
+  end
+
+  it "organizes other interactors" do
+    expect(described_class.organized).to eq(expected_interactors)
+  end
+end

--- a/spec/interactors/hotels/destroy_spec.rb
+++ b/spec/interactors/hotels/destroy_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe Hotels::Destroy do
+  subject(:context) { described_class.call(record: hotel) }
+
+  let!(:hotel) { create :hotel }
+
+  describe ".call" do
+    it { is_expected.to be_success }
+
+    it "destroys hotel" do
+      expect { context }.to change { Hotel.count }.by(-1)
+    end
+  end
+end

--- a/spec/interactors/hotels/save_spec.rb
+++ b/spec/interactors/hotels/save_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Hotels::Save do
+  subject(:context) { described_class.call(record: hotel) }
+
+  let(:hotel) { build :hotel }
+
+  describe ".call" do
+    it { is_expected.to be_success }
+
+    it "saves hotel" do
+      expect { context }.to change { Hotel.count }.by(1)
+    end
+
+    context "when hotel is invalid" do
+      let(:hotel) { build :hotel, name: "" }
+
+      it { is_expected.to be_failure }
+
+      it "doesn't save hotel" do
+        expect { context }.not_to change { Hotel.count }
+      end
+    end
+  end
+end

--- a/spec/interactors/hotels/save_spec.rb
+++ b/spec/interactors/hotels/save_spec.rb
@@ -18,7 +18,7 @@ describe Hotels::Save do
       it { is_expected.to be_failure }
 
       it "doesn't save hotel" do
-        expect { context }.not_to change { Hotel.count }
+        expect { context }.not_to(change { Hotel.count })
       end
     end
   end

--- a/spec/interactors/hotels/update_spec.rb
+++ b/spec/interactors/hotels/update_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe Hotels::Update do
+  subject(:context) { described_class.call(record: hotel, record_params: hotel_params) }
+
+  let(:hotel) { create :hotel, name: "Hotel Nogai", address: "Profsoyuznaya str. 16B, Kazan" }
+  let(:hotel_params) { ActionController::Parameters.new(hotel_attributes) }
+  let(:hotel_attributes) { { name: "Hotel complex Tatarstan" } }
+
+  describe ".call" do
+    it "updates hotel" do
+      is_expected.to be_success
+
+      expect(hotel.reload).to have_attributes(name: "Hotel complex Tatarstan")
+    end
+
+    context "when hotel params are invalid" do
+      let(:hotel_attributes) { { name: "" } }
+
+      it "doesn't update hotel" do
+        is_expected.to be_failure
+
+        expect(hotel.reload).to have_attributes(name: "Hotel Nogai")
+      end
+    end
+  end
+end

--- a/spec/interactors/reindex_multisearch_table_spec.rb
+++ b/spec/interactors/reindex_multisearch_table_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe ReindexMultisearchTable do
+  subject(:context) { described_class.call(record: hotel) }
+
+  let(:hotel) { create :hotel }
+
+  before { hotel.update(name: "New Name") }
+
+  describe ".call" do
+    it { is_expected.to be_success }
+
+    it "rebuilds multisearch table" do
+      expect(PgSearch::Multisearch).to receive(:rebuild).with(Hotel)
+
+      context
+    end
+
+    context "when record was deleted" do
+      before { hotel.destroy }
+
+      it "rebuilds multisearch table" do
+        expect(PgSearch::Multisearch).to receive(:rebuild).with(Hotel)
+
+        context
+      end
+    end
+
+    context "when searchable searchable_attributes were not changes" do
+      before { hotel.update(latitude: 44.6437643) }
+
+      it "rebuilds multisearch table" do
+        expect(PgSearch::Multisearch).not_to receive(:rebuild)
+
+        context
+      end
+    end
+  end
+end

--- a/spec/interactors/reindex_multisearch_table_spec.rb
+++ b/spec/interactors/reindex_multisearch_table_spec.rb
@@ -29,7 +29,7 @@ describe ReindexMultisearchTable do
     context "when searchable searchable_attributes were not changes" do
       before { hotel.update(latitude: 44.6437643) }
 
-      it "rebuilds multisearch table" do
+      it "doesn't rebuild multisearch table" do
         expect(PgSearch::Multisearch).not_to receive(:rebuild)
 
         context

--- a/spec/interactors/reindex_multisearch_table_spec.rb
+++ b/spec/interactors/reindex_multisearch_table_spec.rb
@@ -26,7 +26,7 @@ describe ReindexMultisearchTable do
       end
     end
 
-    context "when searchable attributes were not changes" do
+    context "when searchable attributes were not changed" do
       before { hotel.update(latitude: 44.6437643) }
 
       it "doesn't rebuild multisearch table" do

--- a/spec/interactors/reindex_multisearch_table_spec.rb
+++ b/spec/interactors/reindex_multisearch_table_spec.rb
@@ -26,7 +26,7 @@ describe ReindexMultisearchTable do
       end
     end
 
-    context "when searchable searchable_attributes were not changes" do
+    context "when searchable attributes were not changes" do
       before { hotel.update(latitude: 44.6437643) }
 
       it "doesn't rebuild multisearch table" do

--- a/spec/interactors/update_hotel_spec.rb
+++ b/spec/interactors/update_hotel_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe UpdateHotel do
+  let(:expected_interactors) do
+    [
+      Hotels::Update,
+      ReindexMultisearchTable
+    ]
+  end
+
+  it "organizes other interactors" do
+    expect(described_class.organized).to eq(expected_interactors)
+  end
+end

--- a/spec/support/action_controller_parameters.rb
+++ b/spec/support/action_controller_parameters.rb
@@ -1,0 +1,1 @@
+ActionController::Parameters.permit_all_parameters = true


### PR DESCRIPTION
Replace callback to reindex `pg_search_documents` table with interactor to avoid update of `pg_search_documents` table each time when hotel was updated (because hotel includes many attributes which are not using in search).